### PR TITLE
Add blog post about Snyk Code static analysis and custom SQL injection mitigation

### DIFF
--- a/_posts/2023-04-10-snyk-code-static-analysis.md
+++ b/_posts/2023-04-10-snyk-code-static-analysis.md
@@ -1,0 +1,86 @@
+---
+title: Snyk Code Static Analysis and Custom SQL Injection Mitigation in C#
+date: 2023-04-10
+tags: [Snyk, Static Analysis, SQL Injection, C#, Regex]
+---
+
+# Snyk Code Static Analysis and Custom SQL Injection Mitigation in C#
+
+When using Snyk Code static analysis to detect SQL injection vulnerabilities in C#, it is important to note that Snyk Code won't detect a custom SQL injection mitigation that validates dynamic column names against a Regex unless there is a local Regex variable declaration. The actual Regex can be statically defined elsewhere, but there needs to be a local reference to it in order for Snyk to detect that attack vectors were successfully mitigated.
+
+## Example Code
+
+Here is an example of the code that demonstrates the issue:
+
+```csharp
+using System;
+using System.Data.SqlClient;
+using System.Text.RegularExpressions;
+
+public class SqlInjectionMitigation
+{
+    private static readonly Regex ColumnNameRegex = new Regex("^[a-zA-Z0-9_]+$");
+
+    public void ExecuteQuery(string columnName)
+    {
+        if (!ColumnNameRegex.IsMatch(columnName))
+        {
+            throw new ArgumentException("Invalid column name");
+        }
+
+        string query = $"SELECT {columnName} FROM Users";
+        using (SqlConnection connection = new SqlConnection("your_connection_string"))
+        {
+            SqlCommand command = new SqlCommand(query, connection);
+            connection.Open();
+            SqlDataReader reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                Console.WriteLine(reader[0]);
+            }
+        }
+    }
+}
+```
+
+In the above code, the `ColumnNameRegex` is defined as a static readonly field. However, Snyk Code static analysis won't detect the custom SQL injection mitigation because there is no local Regex variable declaration.
+
+## Solution
+
+To ensure that Snyk Code detects the custom SQL injection mitigation, you need to add a local Regex variable declaration. Here is the modified code:
+
+```csharp
+using System;
+using System.Data.SqlClient;
+using System.Text.RegularExpressions;
+
+public class SqlInjectionMitigation
+{
+    private static readonly Regex ColumnNameRegex = new Regex("^[a-zA-Z0-9_]+$");
+
+    public void ExecuteQuery(string columnName)
+    {
+        // Local Regex variable declaration
+        Regex localColumnNameRegex = ColumnNameRegex;
+
+        if (!localColumnNameRegex.IsMatch(columnName))
+        {
+            throw new ArgumentException("Invalid column name");
+        }
+
+        string query = $"SELECT {columnName} FROM Users";
+        using (SqlConnection connection = new SqlConnection("your_connection_string"))
+        {
+            SqlCommand command = new SqlCommand(query, connection);
+            connection.Open();
+            SqlDataReader reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                Console.WriteLine(reader[0]);
+            }
+        }
+    }
+}
+```
+
+By adding the local Regex variable declaration `Regex localColumnNameRegex = ColumnNameRegex;`, Snyk Code static analysis will now detect the custom SQL injection mitigation and recognize that the attack vectors have been successfully mitigated.


### PR DESCRIPTION
Add a new blog post explaining that Snyk Code static analysis won't detect a custom SQL injection mitigation that validates dynamic column names against a Regex in C# unless there is a local Regex variable declaration.

* Provide an example of the code that demonstrates the issue.
* Explain the solution of adding a local Regex variable declaration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/carlin-q-scott/carlin-q-scott.github.io/pull/15?shareId=e277e216-dfa1-40b3-a864-5ea0c810d027).